### PR TITLE
Add missing deadline on the Posix and windows side

### DIFF
--- a/basic_test.go
+++ b/basic_test.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package serial

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/jonaz/serial
 
 go 1.20
 
-require golang.org/x/sys v0.15.0
+require golang.org/x/sys v0.26.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-golang.org/x/sys v0.15.0 h1:h48lPFYpsTvQJZF4EKyI4aLHaev3CxivZmv7yZig9pc=
-golang.org/x/sys v0.15.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.26.0 h1:KHjCJyddX0LoSTb3J+vWpupP9p0oznkqVk/IfjymZbo=
+golang.org/x/sys v0.26.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/serial_posix.go
+++ b/serial_posix.go
@@ -1,3 +1,4 @@
+//go:build !windows && !linux && cgo
 // +build !windows,!linux,cgo
 
 package serial
@@ -17,7 +18,14 @@ import (
 	//"unsafe"
 )
 
-func openPort(name string, baud int, databits byte, parity Parity, stopbits StopBits, readTimeout time.Duration) (p *Port, err error) {
+func openPort(
+	name string,
+	baud int,
+	databits byte,
+	parity Parity,
+	stopbits StopBits,
+	readTimeout time.Duration,
+) (p *Port, err error) {
 	f, err := os.OpenFile(name, syscall.O_RDWR|syscall.O_NOCTTY|syscall.O_NONBLOCK, 0666)
 	if err != nil {
 		return
@@ -146,10 +154,12 @@ func openPort(name string, baud int, databits byte, parity Parity, stopbits Stop
 	}
 
 	//fmt.Println("Tweaking", name)
-	r1, _, e := syscall.Syscall(syscall.SYS_FCNTL,
+	r1, _, e := syscall.Syscall(
+		syscall.SYS_FCNTL,
 		uintptr(f.Fd()),
 		uintptr(syscall.F_SETFL),
-		uintptr(0))
+		uintptr(0),
+	)
 	if e != 0 || r1 != 0 {
 		s := fmt.Sprint("Clearing NONBLOCK syscall error:", e, r1)
 		f.Close()
@@ -183,6 +193,10 @@ func (p *Port) Read(b []byte) (n int, err error) {
 
 func (p *Port) Write(b []byte) (n int, err error) {
 	return p.f.Write(b)
+}
+
+func (p *Port) SetReadDeadline(t time.Time) (err error) {
+	return p.f.SetReadDeadline(t)
 }
 
 // Discards data written to the port but not transmitted,


### PR DESCRIPTION
This prevents successful builds on non-linux systems of Gombus.
Whitespace/ newline only changes are due to `go fmt`